### PR TITLE
firmware: v0.1 baseline

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -23,6 +23,7 @@ ignoreRegExpList:
   - '"recommendations"\s*:\s*\[[\s\S]*?\]'
 words:
   - ˈwɑːŋkəl
+  - ADON
   - AGND
   - atopile
   - AVIN
@@ -31,9 +32,11 @@ words:
   - boiz
   - bunx
   - cachix
+  - CCITT
   - CCMRAM
   - cfgr
   - clippy
+  - Cnst
   - codegen
   - COMMONINOUT
   - datasheet
@@ -41,12 +44,16 @@ words:
   - drei
   - eabihf
   - Elec
+  - eocie
+  - eocs
+  - exten
   - gpioa
   - gpioc
   - gpioe
   - gpiof
   - HASL
   - hclk
+  - iads
   - INPC
   - INPH
   - Intuos
@@ -74,6 +81,7 @@ words:
   - opencollective
   - OUTPC
   - OUTPH
+  - oversample
   - PCBA
   - pclk
   - PGND
@@ -93,8 +101,10 @@ words:
   - rybbit
   - sclk
   - serde
+  - smpr
   - SWCLK
   - SWDIO
+  - swstart
   - sysclk
   - TAXM8M4RFDCET2T
   - thumbv
@@ -103,6 +113,7 @@ words:
   - trivago
   - trst
   - turbopack
+  - uninit
   - UART
   - USART
   - usbd
@@ -124,6 +135,7 @@ words:
   - Wonkleboard
   - wonkleio
   - Wonklepad
+  - WYSFI
   - xlink
   - xout
   - Xtal

--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "stm32f4xx-hal",
  "usb-device",
  "usbd-hid",
+ "usbd-serial",
 ]
 
 [[package]]
@@ -656,6 +657,18 @@ dependencies = [
  "serde",
  "syn 1.0.109",
  "usbd-hid-descriptors",
+]
+
+[[package]]
+name = "usbd-serial"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065e4eaf93db81d5adac82d9cef8f8da314cb640fa7f89534b972383f1cf80fc"
+dependencies = [
+ "embedded-hal 0.2.7",
+ "embedded-io",
+ "nb 1.1.0",
+ "usb-device",
 ]
 
 [[package]]

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0.219", default-features = false }
 
 # USB
 usb-device = "0.3.2"
+usbd-serial = "0.2.2"
 usbd-hid = "0.8.2"
 
 # See https://defmt.ferrous-systems.com/setup

--- a/firmware/src/crc16.rs
+++ b/firmware/src/crc16.rs
@@ -1,0 +1,40 @@
+//! CRC-16-CCITT XModem, poly 0x1021, init 0x0000, no final xor, MSB-first, no reflection.
+
+const POLY: u16 = 0x1021;
+
+const fn table_entry(index: u16) -> u16 {
+    let mut crc = index << 8;
+    let mut i = 0;
+    while i < 8 {
+        if crc & 0x8000 != 0 {
+            crc = (crc << 1) ^ POLY;
+        } else {
+            crc <<= 1;
+        }
+        i += 1;
+    }
+    crc
+}
+
+const fn build_table() -> [u16; 256] {
+    let mut t = [0u16; 256];
+    let mut i = 0;
+    while i < 256 {
+        t[i] = table_entry(i as u16);
+        i += 1;
+    }
+    t
+}
+
+const CRC16_TABLE: [u16; 256] = build_table();
+
+pub fn crc16_ccitt(data: &[u8]) -> u16 {
+    let mut crc: u16 = 0;
+
+    for &b in data {
+        let idx = (((crc >> 8) as u8) ^ b) as usize;
+        crc = (crc << 8) ^ CRC16_TABLE[idx];
+    }
+
+    crc
+}

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -2,83 +2,130 @@
 #![no_main]
 #![no_std]
 
+mod crc16;
+mod profiler;
+mod sensor;
+mod tablet;
+mod telemetry;
+mod usb;
+
 use defmt_rtt as _;
 // See https://defmt.ferrous-systems.com/global-logger for more information
 use panic_probe as _; // Print panic message to probe console
-use stm32f4xx_hal::{
-    adc::{Adc, config::AdcConfig},
-    otg_fs::USB,
-    pac::Peripherals,
-    prelude::*,
-    rcc::Config,
-};
+use stm32f4xx_hal::{otg_fs, pac, prelude::*, rcc::Config};
 
-mod sensor;
-mod tablet;
-mod usb;
+const USB_ENUMERATION_DELAY_MS: u32 = 3000;
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
-    let dp = Peripherals::take().unwrap(); // device peripheral
+    defmt::info!("Hello from Wonkle!");
+
+    let dp = pac::Peripherals::take().unwrap(); // device peripheral
+    let mut cp = cortex_m::peripheral::Peripherals::take().unwrap(); // core peripheral
     let mut rcc = dp.RCC.freeze(
         Config::hsi()
-            .sysclk(48.MHz())
-            .pclk1(24.MHz())
-            .require_pll48clk(),
+            .sysclk(84.MHz()) // HCLK
+            .pclk1(42.MHz()) // APB1
+            .pclk2(84.MHz()) // APB2
+            .require_pll48clk(), // PLL
     );
+
+    profiler::enable_cycle_counter(&mut cp.DCB, &mut cp.DWT);
 
     let gpioa = dp.GPIOA.split(&mut rcc);
     let gpioc = dp.GPIOC.split(&mut rcc);
     let gpioe = dp.GPIOE.split(&mut rcc);
     let gpiof = dp.GPIOF.split(&mut rcc);
 
-    let mut sensor = sensor::Sensor::new(
-        Adc::new(dp.ADC2, true, AdcConfig::default(), &mut rcc),
-        Adc::new(dp.ADC3, true, AdcConfig::default(), &mut rcc),
+    // sensor input pins
+    let _ = gpioa.pa1.into_analog();
+    let _ = gpioa.pa2.into_analog();
+    let _ = gpioa.pa3.into_analog();
+    let _ = gpioa.pa4.into_analog();
+    let _ = gpioa.pa6.into_analog();
+    let _ = gpioa.pa7.into_analog();
+    let _ = gpioc.pc1.into_analog();
+    let _ = gpioc.pc2.into_analog();
+    let _ = gpioc.pc3.into_analog();
+    let _ = gpioc.pc4.into_analog();
+    let _ = gpioc.pc5.into_analog();
+    let _ = gpiof.pf3.into_analog();
+    let _ = gpiof.pf4.into_analog();
+    let _ = gpiof.pf5.into_analog();
+    let _ = gpiof.pf6.into_analog();
+    let _ = gpiof.pf7.into_analog();
+    let _ = gpiof.pf8.into_analog();
+    let _ = gpiof.pf9.into_analog();
+    let _ = gpiof.pf10.into_analog();
+
+    let mux: sensor::MuxSelect = (
         gpioe.pe6.into_push_pull_output(),
         gpioe.pe5.into_push_pull_output(),
         gpioe.pe4.into_push_pull_output(),
         gpioe.pe3.into_push_pull_output(),
-        gpiof.pf3.into_analog(),
-        gpiof.pf4.into_analog(),
-        gpiof.pf5.into_analog(),
-        gpiof.pf6.into_analog(),
-        gpiof.pf7.into_analog(),
-        gpiof.pf8.into_analog(),
-        gpiof.pf9.into_analog(),
-        gpiof.pf10.into_analog(),
-        gpioc.pc1.into_analog(),
-        gpioc.pc2.into_analog(),
-        gpioc.pc3.into_analog(),
-        gpioa.pa1.into_analog(),
-        gpioa.pa2.into_analog(),
-        gpioa.pa3.into_analog(),
-        gpioa.pa4.into_analog(),
-        gpioa.pa6.into_analog(),
-        gpioa.pa7.into_analog(),
-        gpioc.pc4.into_analog(),
-        gpioc.pc5.into_analog(),
+    )
+        .outport();
+
+    let usb_peripheral = otg_fs::USB::new(
+        (dp.OTG_FS_GLOBAL, dp.OTG_FS_DEVICE, dp.OTG_FS_PWRCLK),
+        (gpioa.pa11, gpioa.pa12),
+        &rcc.clocks,
     );
 
-    usb::setup(USB {
-        usb_global: dp.OTG_FS_GLOBAL,
-        usb_device: dp.OTG_FS_DEVICE,
-        usb_pwrclk: dp.OTG_FS_PWRCLK,
-        pin_dm: gpioa.pa11.into(),
-        pin_dp: gpioa.pa12.into(),
-        hclk: rcc.clocks.hclk(),
-    });
+    defmt::info!(
+        "Waiting {}ms for USB enumeration...",
+        USB_ENUMERATION_DELAY_MS
+    );
+    cp.SYST
+        .delay(&rcc.clocks)
+        .delay_ms(USB_ENUMERATION_DELAY_MS);
 
-    let mut report = tablet::Report::default();
+    defmt::info!("Initializing...");
+    let mut usb_device = usb::build(usb_peripheral);
+    let mut sensor_grid = sensor::SensorGrid::new(dp.ADC2, dp.ADC3, mux, &mut rcc);
+    let mut profiler = profiler::PerformanceProfiler::new(rcc.clocks.sysclk().raw());
+    profiler.init();
+    let mut telemetry = telemetry::Telemetry::new();
+    let mut tablet = tablet::Tablet::new();
+    let mut grid_buffer = [0u16; sensor::SENSOR_COUNT];
 
-    // let button_pin = gpioe.pe2.into_pull_up_input();
+    defmt::info!("Initialized!");
+    defmt::info!(
+        "Config: mux_settling={}, adc_sampling={}, re_reads={}",
+        sensor_grid.mux_settling(),
+        sensor::adc_sampling_label(sensor_grid.adc_sampling()),
+        sensor_grid.adc_re_reads()
+    );
+    defmt::info!(
+        "Filters: ema_alpha_per_mille={}",
+        sensor_grid.ema_alpha() * 1000.0
+    );
 
     loop {
-        let (x, y) = sensor.scan();
-        report.x = x;
-        report.y = y;
+        profiler.begin(true);
 
-        usb::poll();
-        usb::push(report).ok().unwrap_or(0);
+        // Pump USB first so CDC RX is fresh for the host commands, then dispatch any commands.
+        usb_device.poll();
+        telemetry.service(&mut usb_device, &mut sensor_grid, &profiler);
+        profiler.mark_telemetry_service();
+
+        sensor_grid.scan_grid(&mut grid_buffer);
+        profiler.mark_scan();
+        profiler.record_scan_details(sensor_grid.last_scan_timing());
+
+        let mut cursor = tablet.find_centroid(&grid_buffer);
+        profiler.mark_centroid();
+
+        tablet.update_cursor(&sensor_grid, &mut cursor, &usb_device);
+        profiler.mark_usb();
+        profiler.report_if_due();
+
+        telemetry.feed_grid(
+            &grid_buffer,
+            cursor.x,
+            cursor.y,
+            cursor.valid,
+            &mut usb_device,
+        );
     }
 }

--- a/firmware/src/profiler.rs
+++ b/firmware/src/profiler.rs
@@ -1,0 +1,257 @@
+use cortex_m::peripheral::DWT;
+
+pub const REPORT_INTERVAL_MS: u32 = 2000;
+
+/// Microsecond timings captured
+#[derive(Copy, Clone, Default)]
+pub struct ScanTiming {
+    pub mux_cycles: u32,
+    pub single_read_cycles: u32,
+    pub tuning_overhead_cycles: u32,
+}
+
+pub struct PerformanceProfiler {
+    enabled: bool,
+    sysclk_hz: u32,
+
+    t_begin: u32,
+    t_telemetry_service: u32,
+    t_scan: u32,
+    t_centroid: u32,
+    t_usb: u32,
+
+    tick_start_cycles: u32,
+    iterations: u32,
+    sum_telemetry_service: u64,
+    sum_scan: u64,
+    sum_centroid: u64,
+    sum_usb: u64,
+    sum_cycles: u64,
+    sum_mux: u64,
+    sum_single_read: u64,
+    sum_tuning_overhead: u64,
+
+    last_hz: u32,
+    last_telemetry_service_us: u32,
+    last_scan_us: u32,
+    last_centroid_us: u32,
+    last_usb_us: u32,
+    last_mux_us: u32,
+    last_single_read_us: u32,
+    last_tuning_overhead_us: u32,
+}
+
+impl PerformanceProfiler {
+    pub const fn new(sysclk_hz: u32) -> Self {
+        Self {
+            enabled: false,
+            sysclk_hz,
+            t_begin: 0,
+            t_telemetry_service: 0,
+            t_scan: 0,
+            t_centroid: 0,
+            t_usb: 0,
+            tick_start_cycles: 0,
+            iterations: 0,
+            sum_telemetry_service: 0,
+            sum_scan: 0,
+            sum_centroid: 0,
+            sum_usb: 0,
+            sum_cycles: 0,
+            sum_mux: 0,
+            sum_single_read: 0,
+            sum_tuning_overhead: 0,
+            last_hz: 0,
+            last_telemetry_service_us: 0,
+            last_scan_us: 0,
+            last_centroid_us: 0,
+            last_usb_us: 0,
+            last_mux_us: 0,
+            last_single_read_us: 0,
+            last_tuning_overhead_us: 0,
+        }
+    }
+
+    /// Capture the report-interval start timestamp.
+    /// Must be called once at startup, *after* the DWT cycle counter has been enabled.
+    pub fn init(&mut self) {
+        self.tick_start_cycles = DWT::cycle_count();
+    }
+
+    /// Enable the profiler. Must be called at the top of each tick.
+    pub fn begin(&mut self, enabled: bool) {
+        self.enabled = enabled;
+
+        if !enabled {
+            return;
+        }
+
+        self.t_begin = DWT::cycle_count();
+    }
+
+    pub fn mark_telemetry_service(&mut self) {
+        if !self.enabled {
+            return;
+        }
+        self.t_telemetry_service = DWT::cycle_count();
+    }
+
+    pub fn mark_scan(&mut self) {
+        if !self.enabled {
+            return;
+        }
+        self.t_scan = DWT::cycle_count();
+    }
+
+    pub fn mark_centroid(&mut self) {
+        if !self.enabled {
+            return;
+        }
+        self.t_centroid = DWT::cycle_count();
+    }
+
+    pub fn mark_usb(&mut self) {
+        if !self.enabled {
+            return;
+        }
+        self.t_usb = DWT::cycle_count();
+        self.sum_telemetry_service += self.t_telemetry_service.wrapping_sub(self.t_begin) as u64;
+        self.sum_scan += self.t_scan.wrapping_sub(self.t_telemetry_service) as u64;
+        self.sum_centroid += self.t_centroid.wrapping_sub(self.t_scan) as u64;
+        self.sum_usb += self.t_usb.wrapping_sub(self.t_centroid) as u64;
+        self.sum_cycles += self.t_usb.wrapping_sub(self.t_begin) as u64;
+        self.iterations += 1;
+    }
+
+    pub fn record_scan_details(&mut self, t: &ScanTiming) {
+        if !self.enabled {
+            return;
+        }
+        self.sum_mux += t.mux_cycles as u64;
+        self.sum_single_read += t.single_read_cycles as u64;
+        self.sum_tuning_overhead += t.tuning_overhead_cycles as u64;
+    }
+
+    pub fn report_if_due(&mut self) {
+        if !self.enabled {
+            return;
+        }
+        let now = DWT::cycle_count();
+        let cycles_per_ms = self.sysclk_hz / 1000;
+        let elapsed_ms = now.wrapping_sub(self.tick_start_cycles) / cycles_per_ms.max(1);
+        if elapsed_ms < REPORT_INTERVAL_MS {
+            return;
+        }
+
+        let iterations = self.iterations.max(1) as u64;
+        let clk = self.sysclk_hz as u64;
+
+        let hz = if elapsed_ms > 0 {
+            (self.iterations as u64 * 1000) / elapsed_ms as u64
+        } else {
+            0
+        };
+        let us_total = (self.sum_cycles * 1_000_000) / (iterations * clk);
+        let us_telemetry_service = (self.sum_telemetry_service * 1_000_000) / (iterations * clk);
+        let us_scan = (self.sum_scan * 1_000_000) / (iterations * clk);
+        let us_centroid = (self.sum_centroid * 1_000_000) / (iterations * clk);
+        let us_usb = (self.sum_usb * 1_000_000) / (iterations * clk);
+        let us_mux = (self.sum_mux * 1_000_000) / (iterations * clk);
+        let us_single_read = (self.sum_single_read * 1_000_000) / (iterations * clk);
+        let us_tuning_overhead = (self.sum_tuning_overhead * 1_000_000) / (iterations * clk);
+
+        self.last_hz = hz as u32;
+        self.last_telemetry_service_us = us_telemetry_service as u32;
+        self.last_scan_us = us_scan as u32;
+        self.last_centroid_us = us_centroid as u32;
+        self.last_usb_us = us_usb as u32;
+        self.last_mux_us = us_mux as u32;
+        self.last_single_read_us = us_single_read as u32;
+        self.last_tuning_overhead_us = us_tuning_overhead as u32;
+
+        // Percentages reported as per mille (x1000) for one-decimal output.
+        let pct_telemetry_service = if self.sum_cycles > 0 {
+            (self.sum_telemetry_service * 1000) / self.sum_cycles
+        } else {
+            0
+        };
+        let pct_scan = if self.sum_cycles > 0 {
+            (self.sum_scan * 1000) / self.sum_cycles
+        } else {
+            0
+        };
+        let pct_centroid = if self.sum_cycles > 0 {
+            (self.sum_centroid * 1000) / self.sum_cycles
+        } else {
+            0
+        };
+        let pct_usb = if self.sum_cycles > 0 {
+            (self.sum_usb * 1000) / self.sum_cycles
+        } else {
+            0
+        };
+
+        defmt::info!(
+            "{}Hz  {}us/frame  (telemetry: {}.{}%  scan: {}.{}%  centroid: {}.{}%  usb: {}.{}%)",
+            hz as u32,
+            us_total as u32,
+            pct_telemetry_service as u32 / 10,
+            pct_telemetry_service as u32 % 10,
+            pct_scan as u32 / 10,
+            pct_scan as u32 % 10,
+            pct_centroid as u32 / 10,
+            pct_centroid as u32 % 10,
+            pct_usb as u32 / 10,
+            pct_usb as u32 % 10,
+        );
+        defmt::info!(
+            "         scan details: mux={}us  read={}us  oversample={}",
+            us_mux as u32,
+            us_single_read as u32,
+            us_tuning_overhead as u32,
+        );
+
+        self.tick_start_cycles = DWT::cycle_count();
+        self.iterations = 0;
+        self.sum_telemetry_service = 0;
+        self.sum_scan = 0;
+        self.sum_centroid = 0;
+        self.sum_usb = 0;
+        self.sum_cycles = 0;
+        self.sum_mux = 0;
+        self.sum_single_read = 0;
+        self.sum_tuning_overhead = 0;
+    }
+
+    pub fn last_hz(&self) -> u32 {
+        self.last_hz
+    }
+    pub fn last_telemetry_service_us(&self) -> u32 {
+        self.last_telemetry_service_us
+    }
+    pub fn last_scan_us(&self) -> u32 {
+        self.last_scan_us
+    }
+    pub fn last_centroid_us(&self) -> u32 {
+        self.last_centroid_us
+    }
+    pub fn last_usb_us(&self) -> u32 {
+        self.last_usb_us
+    }
+    pub fn last_mux_us(&self) -> u32 {
+        self.last_mux_us
+    }
+    pub fn last_single_read_us(&self) -> u32 {
+        self.last_single_read_us
+    }
+    pub fn last_tuning_overhead_us(&self) -> u32 {
+        self.last_tuning_overhead_us
+    }
+}
+
+/// Enable the DWT cycle counter once at startup.
+/// The counter is then readable from any context via `DWT::cycle_count()`.
+pub fn enable_cycle_counter(dcb: &mut cortex_m::peripheral::DCB, dwt: &mut DWT) {
+    dcb.enable_trace();
+    dwt.enable_cycle_counter();
+}

--- a/firmware/src/sensor.rs
+++ b/firmware/src/sensor.rs
@@ -1,262 +1,293 @@
-use core::u16;
+use cortex_m::asm;
+use cortex_m::peripheral::DWT;
 
-use stm32f4xx_hal::{
-    adc::{Adc, config::SampleTime},
-    gpio::{Analog, Output, Pin},
-    pac::{ADC2, ADC3},
-};
+use stm32f4xx_hal::adc::config::SampleTime;
+use stm32f4xx_hal::gpio::outport::OutPort4;
+use stm32f4xx_hal::pac;
+use stm32f4xx_hal::pac::adc1::RegisterBlock;
+use stm32f4xx_hal::rcc::{Enable, Rcc, Reset};
 
-pub static mut DATA: [u16; ROW_LEN * COL_LEN] = [0; ROW_LEN * COL_LEN];
+use crate::profiler::ScanTiming;
 
-const MAX: f32 = 10_000.;
-const SAMPLE_TIME: SampleTime = SampleTime::Cycles_3;
-const THRESHOLD: u16 = 2300;
-const ROW_LEN: usize = 11;
-const COL_LEN: usize = 19;
-const CHANNELS: [[bool; 4]; ROW_LEN] = [
-    [false, true, false, true],   // 10
-    [true, false, false, true],   // 9
-    [false, false, false, true],  // 8
-    [false, false, false, false], // 0
-    [true, false, false, false],  // 1
-    [false, true, false, false],  // 2
-    [true, true, false, false],   // 3
-    [false, false, true, false],  // 4
-    [true, false, true, false],   // 5
-    [false, true, true, false],   // 6
-    [true, true, true, false],    // 7
+pub const ROWS: usize = 11;
+pub const COLS: usize = 19;
+pub const SENSOR_COUNT: usize = ROWS * COLS;
+
+pub const SENSOR_ROW_TO_MUX_CHANNEL: [u8; ROWS] = [10, 9, 8, 0, 1, 2, 3, 4, 5, 6, 7];
+
+#[derive(Copy, Clone, Debug)]
+pub enum Adc {
+    // Adc1, // unused
+    Adc2,
+    Adc3,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Column {
+    pub adc: Adc,
+    pub adc_channel: u8,
+}
+
+impl Column {
+    pub const fn new(adc: Adc, adc_channel: u8) -> Self {
+        Self { adc, adc_channel }
+    }
+}
+
+pub const SENSOR_COLUMN_TO_ADC: [Column; COLS] = [
+    Column::new(Adc::Adc3, 9),
+    Column::new(Adc::Adc3, 14),
+    Column::new(Adc::Adc3, 15),
+    Column::new(Adc::Adc3, 4),
+    Column::new(Adc::Adc3, 5),
+    Column::new(Adc::Adc3, 6),
+    Column::new(Adc::Adc3, 7),
+    Column::new(Adc::Adc3, 8),
+    Column::new(Adc::Adc2, 11),
+    Column::new(Adc::Adc2, 12),
+    Column::new(Adc::Adc2, 13),
+    Column::new(Adc::Adc2, 1),
+    Column::new(Adc::Adc2, 2),
+    Column::new(Adc::Adc2, 3),
+    Column::new(Adc::Adc2, 4),
+    Column::new(Adc::Adc2, 6),
+    Column::new(Adc::Adc2, 7),
+    Column::new(Adc::Adc2, 14),
+    Column::new(Adc::Adc2, 15),
 ];
 
-pub struct Sensor {
-    adc2: Adc<ADC2>,
-    adc3: Adc<ADC3>,
+pub const ADC_SAMPLING_COUNT: u8 = 8;
 
-    s0: Pin<'E', 6, Output>,
-    s1: Pin<'E', 5, Output>,
-    s2: Pin<'E', 4, Output>,
-    s3: Pin<'E', 3, Output>,
-
-    in0: Pin<'F', 3, Analog>,
-    in1: Pin<'F', 4, Analog>,
-    in2: Pin<'F', 5, Analog>,
-    in3: Pin<'F', 6, Analog>,
-    in4: Pin<'F', 7, Analog>,
-    in5: Pin<'F', 8, Analog>,
-    in6: Pin<'F', 9, Analog>,
-    in7: Pin<'F', 10, Analog>,
-    in8: Pin<'C', 1, Analog>,
-    in9: Pin<'C', 2, Analog>,
-    in10: Pin<'C', 3, Analog>,
-    in11: Pin<'A', 1, Analog>,
-    in12: Pin<'A', 2, Analog>,
-    in13: Pin<'A', 3, Analog>,
-    in14: Pin<'A', 4, Analog>,
-    in15: Pin<'A', 6, Analog>,
-    in16: Pin<'A', 7, Analog>,
-    in17: Pin<'C', 4, Analog>,
-    in18: Pin<'C', 5, Analog>,
+pub fn adc_sampling_label(s: SampleTime) -> &'static str {
+    match s {
+        SampleTime::Cycles_3 => "3 cyc",
+        SampleTime::Cycles_15 => "15 cyc",
+        SampleTime::Cycles_28 => "28 cyc",
+        SampleTime::Cycles_56 => "56 cyc",
+        SampleTime::Cycles_84 => "84 cyc",
+        SampleTime::Cycles_112 => "112 cyc",
+        SampleTime::Cycles_144 => "144 cyc",
+        SampleTime::Cycles_480 => "480 cyc",
+    }
 }
 
-impl Sensor {
-    pub fn new(
-        adc2: Adc<ADC2>,
-        adc3: Adc<ADC3>,
-        //
-        s0: Pin<'E', 6, Output>,
-        s1: Pin<'E', 5, Output>,
-        s2: Pin<'E', 4, Output>,
-        s3: Pin<'E', 3, Output>,
-        //                            | ADC1 | ADC2 | ADC3 | IN | FUll Name   |
-        in0: Pin<'F', 3, Analog>, //  |      |      |    O | 9  | ADC3_IN9    |
-        in1: Pin<'F', 4, Analog>, //  |      |      |    O | 14 | ADC3_IN14   |
-        in2: Pin<'F', 5, Analog>, //  |      |      |    O | 15 | ADC3_IN15   |
-        in3: Pin<'F', 6, Analog>, //  |      |      |    O | 4  | ADC3_IN4    |
-        in4: Pin<'F', 7, Analog>, //  |      |      |    O | 5  | ADC3_IN5    |
-        in5: Pin<'F', 8, Analog>, //  |      |      |    O | 6  | ADC3_IN6    |
-        in6: Pin<'F', 9, Analog>, //  |      |      |    O | 7  | ADC3_IN7    |
-        in7: Pin<'F', 10, Analog>, // |      |      |    O | 8  | ADC3_IN8    |
-        in8: Pin<'C', 1, Analog>, //  |    O |    O |    O | 11 | ADC123_IN11 |
-        in9: Pin<'C', 2, Analog>, //  |    O |    O |    O | 12 | ADC123_IN12 |
-        in10: Pin<'C', 3, Analog>, // |    O |    O |    O | 13 | ADC123_IN13 |
-        in11: Pin<'A', 1, Analog>, // |    O |    O |    O | 1  | ADC123_IN1  |
-        in12: Pin<'A', 2, Analog>, // |    O |    O |    O | 2  | ADC123_IN2  |
-        in13: Pin<'A', 3, Analog>, // |    O |    O |    O | 3  | ADC123_IN3  |
-        in14: Pin<'A', 4, Analog>, // |    O |    O |      | 4  | ADC12_IN4   |
-        in15: Pin<'A', 6, Analog>, // |    O |    O |      | 6  | ADC12_IN6   |
-        in16: Pin<'A', 7, Analog>, // |    O |    O |      | 7  | ADC12_IN7   |
-        in17: Pin<'C', 4, Analog>, // |    O |    O |      | 14 | ADC12_IN14  |
-        in18: Pin<'C', 5, Analog>, // |    O |    O |      | 15 | ADC12_IN15  |
-    ) -> Sensor {
-        Sensor {
+pub type MuxSelect = OutPort4<'E', 6, 5, 4, 3>;
+
+pub struct SensorGrid {
+    adc2: pac::ADC2,
+    adc3: pac::ADC3,
+    mux: MuxSelect,
+
+    mux_settling: u32,
+    adc_sampling: SampleTime,
+    adc_re_reads: u8,
+    oversample_enabled: bool,
+    ema_alpha: f32,
+
+    last_scan_timing: ScanTiming,
+}
+
+impl SensorGrid {
+    pub fn new(adc2: pac::ADC2, adc3: pac::ADC3, mux: MuxSelect, rcc: &mut Rcc) -> Self {
+        pac::ADC1::enable(rcc);
+        pac::ADC2::enable(rcc);
+        pac::ADC3::enable(rcc);
+        pac::ADC2::reset(rcc);
+
+        Self::configure_adc(&adc2);
+        Self::configure_adc(&adc3);
+
+        let mut grid = Self {
             adc2,
             adc3,
+            mux,
+            mux_settling: 4000,
+            adc_sampling: SampleTime::Cycles_3,
+            adc_re_reads: 3,
+            oversample_enabled: true,
+            ema_alpha: 0.0,
+            last_scan_timing: ScanTiming::default(),
+        };
+        grid.apply_adc_sampling(grid.adc_sampling);
 
-            s0,
-            s1,
-            s2,
-            s3,
+        grid.adc2.cr2().modify(|_, w| w.adon().set_bit());
+        grid.adc3.cr2().modify(|_, w| w.adon().set_bit());
 
-            in0,
-            in1,
-            in2,
-            in3,
-            in4,
-            in5,
-            in6,
-            in7,
-            in8,
-            in9,
-            in10,
-            in11,
-            in12,
-            in13,
-            in14,
-            in15,
-            in16,
-            in17,
-            in18,
+        grid
+    }
+
+    fn configure_adc(adc: &RegisterBlock) {
+        adc.cr1()
+            .modify(|_, w| unsafe { w.res().bits(0).scan().clear_bit().eocie().clear_bit() });
+
+        adc.cr2().modify(|_, w| unsafe {
+            w.align()
+                .clear_bit() // right-aligned data
+                .cont()
+                .clear_bit() // single conversion
+                .dma()
+                .clear_bit() // no DMA
+                .eocs()
+                .clear_bit() // EOC raised after each conversion
+                .exten()
+                .bits(0) // software trigger (EXTEN = disabled)
+        });
+
+        adc.sqr1().modify(|_, w| unsafe { w.l().bits(0) }); // L = 0 => 1 conversion per sequence.
+    }
+
+    /// Program `SMPR` sample-time bits for a single channel on the given ADC.
+    fn set_sample_time(adc: &RegisterBlock, ch: u8, st: u8) {
+        if ch <= 9 {
+            adc.smpr2().modify(|_, w| unsafe { w.smp(ch).bits(st) });
+        } else {
+            adc.smpr1()
+                .modify(|_, w| unsafe { w.smp(ch - 10).bits(st) });
         }
     }
 
-    fn select_row(&mut self, i: usize) {
-        if i > ROW_LEN {
-            defmt::panic!(
-                "mux has a valid range of 0~{} but {} was selected.",
-                ROW_LEN - 1,
-                i
+    fn apply_adc_sampling(&mut self, sampling: SampleTime) {
+        let st = sampling as u8;
+
+        for &col in SENSOR_COLUMN_TO_ADC.iter() {
+            Self::set_sample_time(
+                match col.adc {
+                    Adc::Adc2 => &self.adc2,
+                    Adc::Adc3 => &self.adc3,
+                },
+                col.adc_channel,
+                st,
             );
         }
+    }
 
-        if CHANNELS[i][0] {
-            self.s0.set_high();
+    fn select_row(&mut self, row: u8) {
+        let ch = SENSOR_ROW_TO_MUX_CHANNEL[row as usize];
+        self.mux.write(ch as u32);
+    }
+
+    pub fn scan_grid(&mut self, out: &mut [u16; SENSOR_COUNT]) {
+        let mut mux_total: u32 = 0;
+        let mut read_total: u32 = 0;
+        let mut read_count: u32 = 0;
+        let mut per_sensor_total: u32 = 0;
+
+        for row in 0..ROWS {
+            self.select_row(row as u8);
+
+            {
+                let before = DWT::cycle_count();
+                for _ in 0..self.mux_settling {
+                    asm::nop();
+                }
+                mux_total = mux_total.wrapping_add(DWT::cycle_count().wrapping_sub(before));
+            }
+
+            if !self.oversample_enabled && self.adc_re_reads > 0 {
+                let ch_adc2 = SENSOR_COLUMN_TO_ADC[0].adc_channel;
+                let ch_adc3 = SENSOR_COLUMN_TO_ADC[7].adc_channel;
+                for _ in 0..self.adc_re_reads {
+                    let a2 = &self.adc2;
+                    unsafe { a2.sqr3().write(|w| w.sq1().bits(ch_adc2)) };
+                    a2.cr2().modify(|_, w| w.swstart().set_bit());
+                    while a2.sr().read().eoc().bit_is_clear() {}
+                    let _ = a2.dr().read();
+
+                    let a3 = &self.adc3;
+                    unsafe { a3.sqr3().write(|w| w.sq1().bits(ch_adc3)) };
+                    a3.cr2().modify(|_, w| w.swstart().set_bit());
+                    while a3.sr().read().eoc().bit_is_clear() {}
+                    let _ = a3.dr().read();
+                }
+            }
+
+            for col in 0..COLS {
+                let c = SENSOR_COLUMN_TO_ADC[col];
+                let adc: &RegisterBlock = match c.adc {
+                    Adc::Adc2 => &self.adc2,
+                    Adc::Adc3 => &self.adc3,
+                };
+
+                let before = DWT::cycle_count();
+
+                if self.oversample_enabled {
+                    let total_reads = (self.adc_re_reads as u32) + 1;
+                    let mut acc: u32 = 0;
+                    for _ in 0..total_reads {
+                        unsafe { adc.sqr3().write(|w| w.sq1().bits(c.adc_channel)) };
+                        adc.cr2().modify(|_, w| w.swstart().set_bit());
+                        while adc.sr().read().eoc().bit_is_clear() {}
+                        acc += adc.dr().read().data().bits() as u32;
+                    }
+                    out[row * COLS + col] = (acc / total_reads) as u16;
+                } else {
+                    unsafe { adc.sqr3().write(|w| w.sq1().bits(c.adc_channel)) };
+                    adc.cr2().modify(|_, w| w.swstart().set_bit());
+                    while adc.sr().read().eoc().bit_is_clear() {}
+                    out[row * COLS + col] = adc.dr().read().data().bits();
+
+                    read_total = read_total.wrapping_add(DWT::cycle_count().wrapping_sub(before));
+                    read_count += 1;
+                }
+
+                per_sensor_total =
+                    per_sensor_total.wrapping_add(DWT::cycle_count().wrapping_sub(before));
+            }
+        }
+
+        let total_sensors = SENSOR_COUNT as u32;
+        self.last_scan_timing.mux_cycles = mux_total / (ROWS as u32);
+        self.last_scan_timing.single_read_cycles = if read_count > 0 {
+            read_total / read_count
         } else {
-            self.s0.set_low();
-        }
-
-        if CHANNELS[i][1] {
-            self.s1.set_high();
-        } else {
-            self.s1.set_low();
-        }
-
-        if CHANNELS[i][2] {
-            self.s2.set_high();
-        } else {
-            self.s2.set_low();
-        }
-
-        if CHANNELS[i][3] {
-            self.s3.set_high();
-        } else {
-            self.s3.set_low();
-        }
+            0
+        };
+        self.last_scan_timing.tuning_overhead_cycles = per_sensor_total / total_sensors;
     }
 
-    fn read_row(&mut self, i: usize) {
-        self.select_row(i);
+    pub fn last_scan_timing(&self) -> &ScanTiming {
+        &self.last_scan_timing
+    }
 
-        unsafe {
-            DATA[i * COL_LEN + 00] = threshold(self.adc3.convert(&self.in0, SAMPLE_TIME));
-            DATA[i * COL_LEN + 01] = threshold(self.adc3.convert(&self.in1, SAMPLE_TIME));
-            DATA[i * COL_LEN + 02] = threshold(self.adc3.convert(&self.in2, SAMPLE_TIME));
-            DATA[i * COL_LEN + 03] = threshold(self.adc3.convert(&self.in3, SAMPLE_TIME));
-            DATA[i * COL_LEN + 04] = threshold(self.adc3.convert(&self.in4, SAMPLE_TIME));
-            DATA[i * COL_LEN + 05] = threshold(self.adc3.convert(&self.in5, SAMPLE_TIME));
-            DATA[i * COL_LEN + 06] = threshold(self.adc3.convert(&self.in6, SAMPLE_TIME));
-            DATA[i * COL_LEN + 07] = threshold(self.adc3.convert(&self.in7, SAMPLE_TIME));
-            DATA[i * COL_LEN + 08] = threshold(self.adc2.convert(&self.in8, SAMPLE_TIME));
-            DATA[i * COL_LEN + 09] = threshold(self.adc2.convert(&self.in9, SAMPLE_TIME));
-            DATA[i * COL_LEN + 10] = threshold(self.adc2.convert(&self.in10, SAMPLE_TIME));
-            DATA[i * COL_LEN + 11] = threshold(self.adc2.convert(&self.in11, SAMPLE_TIME));
-            DATA[i * COL_LEN + 12] = threshold(self.adc2.convert(&self.in12, SAMPLE_TIME));
-            DATA[i * COL_LEN + 13] = threshold(self.adc2.convert(&self.in13, SAMPLE_TIME));
-            DATA[i * COL_LEN + 14] = threshold(self.adc2.convert(&self.in14, SAMPLE_TIME));
-            DATA[i * COL_LEN + 15] = threshold(self.adc2.convert(&self.in15, SAMPLE_TIME));
-            DATA[i * COL_LEN + 16] = threshold(self.adc2.convert(&self.in16, SAMPLE_TIME));
-            DATA[i * COL_LEN + 17] = threshold(self.adc2.convert(&self.in17, SAMPLE_TIME));
-            DATA[i * COL_LEN + 18] = threshold(self.adc2.convert(&self.in18, SAMPLE_TIME));
+    pub fn mux_settling(&self) -> u32 {
+        self.mux_settling
+    }
+    pub fn set_mux_settling(&mut self, cycles: u32) {
+        self.mux_settling = cycles;
+    }
 
-            // defmt::info!(
-            //     "{:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03} {:03}",
-            //     DATA[i * COL_LEN + 00],
-            //     DATA[i * COL_LEN + 01],
-            //     DATA[i * COL_LEN + 02],
-            //     DATA[i * COL_LEN + 03],
-            //     DATA[i * COL_LEN + 04],
-            //     DATA[i * COL_LEN + 05],
-            //     DATA[i * COL_LEN + 06],
-            //     DATA[i * COL_LEN + 07],
-            //     DATA[i * COL_LEN + 08],
-            //     DATA[i * COL_LEN + 09],
-            //     DATA[i * COL_LEN + 10],
-            //     DATA[i * COL_LEN + 11],
-            //     DATA[i * COL_LEN + 12],
-            //     DATA[i * COL_LEN + 13],
-            //     DATA[i * COL_LEN + 14],
-            //     DATA[i * COL_LEN + 15],
-            //     DATA[i * COL_LEN + 16],
-            //     DATA[i * COL_LEN + 17],
-            //     DATA[i * COL_LEN + 18]
-            // ); // these two should be uncommented together <=====
+    pub fn adc_sampling(&self) -> SampleTime {
+        self.adc_sampling
+    }
+    pub fn set_adc_sampling(&mut self, s: SampleTime) {
+        if (s as u8) >= ADC_SAMPLING_COUNT {
+            return;
         }
+        self.adc_sampling = s;
+        self.apply_adc_sampling(s);
     }
 
-    pub fn scan(&mut self) -> (u16, u16) {
-        // defmt::info!(""); // these two should be uncommented together <=====
-
-        for i in 0..ROW_LEN {
-            self.read_row(i);
+    pub fn adc_re_reads(&self) -> u8 {
+        self.adc_re_reads
+    }
+    pub fn set_adc_re_reads(&mut self, count: u8) {
+        if count > 10 {
+            return;
         }
-
-        return find_center();
-    }
-}
-
-pub fn threshold(val: u16) -> u16 {
-    if val < THRESHOLD { 0 } else { val - THRESHOLD }
-}
-
-fn find_center() -> (u16, u16) {
-    // u16::MAX is 65_535
-    // u32::MAX is 4_294_967_295
-    //
-    // const ROW_LEN: usize = 11;
-    // const COL_LEN: usize = 19;
-    //
-    // fn main() {
-    //     let mut total = 0u32;
-    //     let mut sum_x = 0u32;
-    //     let mut sum_y = 0u32;
-    //
-    //     for i in 0..ROW_LEN * COL_LEN {
-    //         total += u16::MAX as u32;
-    //         sum_x += u16::MAX as u32 * (i % COL_LEN + 1) as u32;
-    //         sum_y += u16::MAX as u32 * (i / COL_LEN + 1) as u32;
-    //     }
-    //
-    //     println!("{} {} {}", total, sum_x, sum_y); // 13_696_815 136_968_150 82_180_890
-    // }
-
-    let mut total = 0u32;
-    let mut sum_x = 0u32;
-    let mut sum_y = 0u32;
-    let mut i = 0;
-
-    unsafe {
-        for v in DATA {
-            sum_x += v as u32 * (i % COL_LEN) as u32;
-            sum_y += v as u32 * (i / COL_LEN) as u32;
-            total += v as u32;
-            i += 1;
-        }
+        self.adc_re_reads = count;
     }
 
-    if total == 0 {
-        return (0, 0);
+    pub fn oversample_enabled(&self) -> bool {
+        self.oversample_enabled
+    }
+    pub fn set_oversample_enabled(&mut self, enabled: bool) {
+        self.oversample_enabled = enabled;
     }
 
-    return (
-        (MAX / (COL_LEN as f32 - 1.) * sum_x as f32 / total as f32) as u16,
-        (MAX / (ROW_LEN as f32 - 1.) * sum_y as f32 / total as f32) as u16,
-    );
+    pub fn ema_alpha(&self) -> f32 {
+        self.ema_alpha
+    }
+    pub fn set_ema_alpha(&mut self, alpha: f32) {
+        self.ema_alpha = alpha;
+    }
 }

--- a/firmware/src/tablet.rs
+++ b/firmware/src/tablet.rs
@@ -1,25 +1,113 @@
 // https://docs.kernel.org/hid/index.html
 
-use usbd_hid::descriptor::generator_prelude::*;
+use crate::sensor::{self, COLS, ROWS, SENSOR_COUNT, SensorGrid};
+use crate::usb::{HID_REPORT_SIZE_BYTES, Usb};
 
-/// See https://usb.org/sites/default/files/hid1_11.pdf to understand how HID works.\
-/// See https://usb.org/sites/default/files/hut1_6.pdf for HID usage tables.\
-/// See [Wacom Intuos Pro S (3rd-gen) HID descriptor] for example.\
-/// See [usbd_hid_macros::spec::try_resolve_constant]
-///
-/// [Wacom Intuos Pro S (3rd-gen) HID descriptor]: https://github.com/linuxwacom/wacom-hid-descriptors/blob/3dd4a3d41d86a9a51c57d7424af26208d51b9097/Wacom%20Intuos%20Pro%20S%20(3rd-gen)/sysinfo.vS9sFVLdTW/0003%3A056A%3A03F5.0008.hid.txt
-#[gen_hid_descriptor(
-    // 0x01 = Digitizer
-    (usage_page=DIGITIZER, usage=0x01, collection=APPLICATION) = {
-        // 0x20 = Stylus
-        (usage=0x20, collection=PHYSICAL) = {
-            (usage_page=UNDEFINED,) = { #[item_settings data,variable,absolute,no_wrap,linear,preferred,not_null,not_volatile] x=input; };
-            (usage_page=UNDEFINED,) = { #[item_settings data,variable,absolute,no_wrap,linear,preferred,not_null,not_volatile] y=input; };
-        };
+const GRID_TO_HID_SCALE: f32 = 10000.0;
+
+#[derive(Copy, Clone, Default)]
+pub struct Cursor {
+    pub x: f32,
+    pub y: f32,
+    pub valid: bool,
+}
+
+pub struct Tablet {
+    threshold: u16,
+    ema_initialized: bool,
+    smoothed_x: f32,
+    smoothed_y: f32,
+}
+
+impl Tablet {
+    pub const fn new() -> Self {
+        Self {
+            threshold: 2200,
+            ema_initialized: false,
+            smoothed_x: 0.0,
+            smoothed_y: 0.0,
+        }
     }
-)]
-#[derive(Default)]
-pub struct Report {
-    pub x: u16,
-    pub y: u16,
+
+    #[allow(dead_code)]
+    pub fn set_threshold(&mut self, t: u16) {
+        self.threshold = t;
+    }
+
+    pub fn find_centroid(&self, grid: &[u16; SENSOR_COUNT]) -> Cursor {
+        let cols = COLS;
+        let rows = ROWS;
+        let threshold = self.threshold;
+
+        let mut sum_x = 0.0_f32;
+        let mut sum_y = 0.0_f32;
+        let mut total = 0.0_f32;
+        let mut clustered_count = 0u32;
+
+        for r in 0..rows {
+            for c in 0..cols {
+                let raw = grid[r * cols + c];
+                if raw > threshold {
+                    let has_neighbor = (r > 0 && grid[(r - 1) * cols + c] > threshold)
+                        || (r + 1 < rows && grid[(r + 1) * cols + c] > threshold)
+                        || (c > 0 && grid[r * cols + c - 1] > threshold)
+                        || (c + 1 < cols && grid[r * cols + c + 1] > threshold);
+
+                    if has_neighbor {
+                        clustered_count += 1;
+                        let val = (raw - threshold) as f32;
+                        sum_x += val * c as f32;
+                        sum_y += val * r as f32;
+                        total += val;
+                    }
+                }
+            }
+        }
+
+        if clustered_count >= 3 && total > 0.0 {
+            Cursor {
+                x: sum_x / total,
+                y: sum_y / total,
+                valid: true,
+            }
+        } else {
+            Cursor {
+                x: 0.0,
+                y: 0.0,
+                valid: false,
+            }
+        }
+    }
+
+    pub fn update_cursor(&mut self, grid: &SensorGrid, cursor: &mut Cursor, usb: &Usb) {
+        let alpha = grid.ema_alpha();
+
+        if alpha > 0.0 {
+            if !self.ema_initialized && cursor.valid {
+                self.smoothed_x = cursor.x;
+                self.smoothed_y = cursor.y;
+                self.ema_initialized = true;
+            } else if self.ema_initialized {
+                self.smoothed_x = alpha * cursor.x + (1.0 - alpha) * self.smoothed_x;
+                self.smoothed_y = alpha * cursor.y + (1.0 - alpha) * self.smoothed_y;
+            }
+            cursor.x = self.smoothed_x;
+            cursor.y = self.smoothed_y;
+        }
+
+        let mut report = [0u8; HID_REPORT_SIZE_BYTES];
+        if cursor.valid {
+            let x_usb = (cursor.x * GRID_TO_HID_SCALE / (sensor::COLS - 1) as f32) as u16;
+            let y_usb = (cursor.y * GRID_TO_HID_SCALE / (sensor::ROWS - 1) as f32) as u16;
+            // report[0] = 0; // buttons
+            report[1] = 0x02; // HID "in range" flag
+            report[2..4].copy_from_slice(&x_usb.to_le_bytes());
+            report[4..6].copy_from_slice(&y_usb.to_le_bytes());
+            // report[6..8] = 0; // tip pressure
+        } else if alpha > 0.0 {
+            self.ema_initialized = false;
+        }
+
+        usb.send_hid_report(&report);
+    }
 }

--- a/firmware/src/telemetry.rs
+++ b/firmware/src/telemetry.rs
@@ -1,0 +1,262 @@
+use stm32f4xx_hal::adc::config::SampleTime;
+
+use crate::crc16::crc16_ccitt;
+use crate::profiler::PerformanceProfiler;
+use crate::sensor::{SENSOR_COUNT, SensorGrid, adc_sampling_label};
+use crate::usb::Usb;
+
+pub const PROTOCOL_VERSION: u8 = 0x01;
+pub const SYNC_LO: u8 = 0xAA;
+pub const SYNC_HI: u8 = 0x55;
+
+pub const SUB_GRID: u8 = 1 << 0;
+
+pub const MSG_GRID: u8 = 0x10;
+pub const MSG_CONFIG: u8 = 0x20;
+pub const MSG_PERF: u8 = 0x30;
+
+pub const CMD_SUBSCRIBE: u8 = 0x01;
+pub const CMD_UNSUBSCRIBE: u8 = 0x04;
+pub const CMD_UNSUBSCRIBE_TO: u8 = 0x06;
+pub const CMD_SET_MUX_SETTLING: u8 = 0x10;
+pub const CMD_SET_ADC_SAMPLING: u8 = 0x11;
+pub const CMD_GET_CONFIG: u8 = 0x12;
+pub const CMD_SET_ADC_RE_READS: u8 = 0x13;
+pub const CMD_SET_ADC_OVERSAMPLE: u8 = 0x14;
+pub const CMD_GET_PERF: u8 = 0x15;
+pub const CMD_SET_EMA_ALPHA: u8 = 0x16;
+
+/// total size = 6 (header) + 418 (209×u16) + 2 + 2 + 1 + 2 (crc) = 431.
+const GRID_FRAME_LEN: usize = 431;
+const GRID_FRAME_CRC_OFFSET: usize = 429;
+
+const CONFIG_FRAME_LEN: usize = 16;
+const PERF_FRAME_LEN: usize = 40;
+
+/// Grid frames are emitted every Nth tick when subscribed.
+const GRID_SEND_EVERY_N_TICKS: u8 = 10;
+
+pub struct Telemetry {
+    subscriptions: u8,
+    frame_counter: u16,
+    grid_tick_counter: u8,
+}
+
+impl Telemetry {
+    pub const fn new() -> Self {
+        Self {
+            subscriptions: 0,
+            frame_counter: 0,
+            grid_tick_counter: 0,
+        }
+    }
+
+    pub fn is_subscribed(&self, flag: u8) -> bool {
+        (self.subscriptions & flag) != 0
+    }
+
+    /// Pump the RX path: pull any pending host command and dispatch it.
+    pub fn service(
+        &mut self,
+        usb: &mut Usb,
+        grid: &mut SensorGrid,
+        profiler: &PerformanceProfiler,
+    ) {
+        let mut buf = [0u8; 64];
+        let n = usb.cdc_rx_pop(&mut buf);
+        if n > 0 {
+            self.on_command(buf[0], &buf[1..n], usb, grid, profiler);
+        }
+    }
+
+    fn on_command(
+        &mut self,
+        cmd: u8,
+        data: &[u8],
+        usb: &mut Usb,
+        grid: &mut SensorGrid,
+        profiler: &PerformanceProfiler,
+    ) {
+        match cmd {
+            CMD_SUBSCRIBE => {
+                let flags = if !data.is_empty() { data[0] } else { SUB_GRID };
+                self.subscriptions |= flags;
+                defmt::info!(
+                    "CDC: subscribe 0x{:02x} (now=0x{:02x})",
+                    flags,
+                    self.subscriptions
+                );
+            }
+            CMD_UNSUBSCRIBE => {
+                self.subscriptions = 0;
+                defmt::info!("CDC: unsubscribe all");
+            }
+            CMD_UNSUBSCRIBE_TO => {
+                if let Some(&flags) = data.first() {
+                    self.subscriptions &= !flags;
+                    defmt::info!(
+                        "CDC: unsubscribe 0x{:02x} (now=0x{:02x})",
+                        flags,
+                        self.subscriptions
+                    );
+                }
+            }
+            CMD_SET_MUX_SETTLING => {
+                if data.len() >= 4 {
+                    let cycles = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+                    grid.set_mux_settling(cycles);
+                    defmt::info!("CDC: mux_settling={}", cycles);
+                }
+            }
+            CMD_SET_ADC_SAMPLING => {
+                if let Some(&idx) = data.first()
+                    && idx < 8
+                {
+                    let s = sampling_from_index(idx);
+                    grid.set_adc_sampling(s);
+                    defmt::info!("CDC: adc_sampling={}", adc_sampling_label(s));
+                }
+            }
+            CMD_GET_CONFIG => {
+                defmt::info!("CDC: get_config requested");
+                self.send_config(grid, usb);
+            }
+            CMD_SET_ADC_RE_READS => {
+                if let Some(&count) = data.first() {
+                    grid.set_adc_re_reads(count);
+                    defmt::info!("CDC: adc_re_reads={}", count);
+                }
+            }
+            CMD_SET_ADC_OVERSAMPLE => {
+                if let Some(&v) = data.first() {
+                    grid.set_oversample_enabled(v != 0);
+                    defmt::info!("CDC: adc_oversample={}", if v != 0 { "on" } else { "off" });
+                }
+            }
+            CMD_GET_PERF => {
+                defmt::info!("CDC: get_perf requested");
+                self.send_perf(profiler, usb);
+            }
+            CMD_SET_EMA_ALPHA => {
+                if let Some(&raw) = data.first() {
+                    let alpha = raw as f32 / 255.0;
+                    grid.set_ema_alpha(alpha);
+                    let per_mille = (alpha * 1000.0) as u32;
+                    defmt::info!("CDC: ema_alpha=0.{:03} (raw={})", per_mille, raw);
+                }
+            }
+            _ => {
+                defmt::warn!("CDC: Unknown command!");
+            }
+        }
+    }
+
+    /// Emit a grid frame every N ticks, if subscribed.
+    pub fn feed_grid(
+        &mut self,
+        grid_buffer: &[u16; SENSOR_COUNT],
+        cx: f32,
+        cy: f32,
+        valid: bool,
+        usb: &mut Usb,
+    ) {
+        self.grid_tick_counter = self.grid_tick_counter.wrapping_add(1);
+        if self.grid_tick_counter < GRID_SEND_EVERY_N_TICKS {
+            return;
+        }
+        self.grid_tick_counter = 0;
+
+        if !self.is_subscribed(SUB_GRID) {
+            return;
+        }
+
+        let mut frame = [0u8; GRID_FRAME_LEN];
+        // Header
+        frame[0] = SYNC_LO;
+        frame[1] = SYNC_HI;
+        frame[2] = PROTOCOL_VERSION;
+        frame[3] = MSG_GRID;
+        frame[4..6].copy_from_slice(&self.frame_counter.to_le_bytes());
+        // values[209]
+        for (i, &v) in grid_buffer.iter().enumerate() {
+            let base = 6 + i * 2;
+            frame[base..base + 2].copy_from_slice(&v.to_le_bytes());
+        }
+        // cursor (scaled x100)
+        let cursor_x = (cx * 100.0) as i16;
+        let cursor_y = (cy * 100.0) as i16;
+        frame[424..426].copy_from_slice(&cursor_x.to_le_bytes());
+        frame[426..428].copy_from_slice(&cursor_y.to_le_bytes());
+        frame[428] = if valid { 1 } else { 0 };
+        // CRC over (header + payload)
+        let crc = crc16_ccitt(&frame[..GRID_FRAME_CRC_OFFSET]);
+        frame[GRID_FRAME_CRC_OFFSET..GRID_FRAME_CRC_OFFSET + 2].copy_from_slice(&crc.to_le_bytes());
+
+        if self.frame_counter < 3 {
+            defmt::info!(
+                "GRID#{} subs=0x{:02x}",
+                self.frame_counter,
+                self.subscriptions
+            );
+        }
+
+        let _ = usb.cdc_send_frame(&frame);
+        self.frame_counter = self.frame_counter.wrapping_add(1);
+    }
+
+    fn send_config(&self, grid: &SensorGrid, usb: &mut Usb) {
+        let mut resp = [0u8; CONFIG_FRAME_LEN];
+        resp[0] = SYNC_LO;
+        resp[1] = SYNC_HI;
+        resp[2] = PROTOCOL_VERSION;
+        resp[3] = MSG_CONFIG;
+        // seq = 0
+        resp[6..10].copy_from_slice(&grid.mux_settling().to_le_bytes());
+        resp[10] = grid.adc_sampling() as u8;
+        resp[11] = grid.adc_re_reads();
+        resp[12] = if grid.oversample_enabled() { 1 } else { 0 };
+        resp[13] = (grid.ema_alpha() * 255.0) as u8;
+        let crc = crc16_ccitt(&resp[..14]);
+        resp[14..16].copy_from_slice(&crc.to_le_bytes());
+        let _ = usb.cdc_send_frame(&resp);
+    }
+
+    fn send_perf(&self, profiler: &PerformanceProfiler, usb: &mut Usb) {
+        let fields: [u32; 8] = [
+            profiler.last_hz(),
+            profiler.last_telemetry_service_us(),
+            profiler.last_scan_us(),
+            profiler.last_centroid_us(),
+            profiler.last_usb_us(),
+            profiler.last_mux_us(),
+            profiler.last_single_read_us(),
+            profiler.last_tuning_overhead_us(),
+        ];
+        let mut resp = [0u8; PERF_FRAME_LEN];
+        resp[0] = SYNC_LO;
+        resp[1] = SYNC_HI;
+        resp[2] = PROTOCOL_VERSION;
+        resp[3] = MSG_PERF;
+        // seq = 0
+        for (i, &f) in fields.iter().enumerate() {
+            let base = 6 + i * 4;
+            resp[base..base + 4].copy_from_slice(&f.to_le_bytes());
+        }
+        let crc = crc16_ccitt(&resp[..38]);
+        resp[38..40].copy_from_slice(&crc.to_le_bytes());
+        let _ = usb.cdc_send_frame(&resp);
+    }
+}
+
+fn sampling_from_index(idx: u8) -> SampleTime {
+    match idx {
+        0 => SampleTime::Cycles_3,
+        1 => SampleTime::Cycles_15,
+        2 => SampleTime::Cycles_28,
+        3 => SampleTime::Cycles_56,
+        4 => SampleTime::Cycles_84,
+        5 => SampleTime::Cycles_112,
+        6 => SampleTime::Cycles_144,
+        _ => SampleTime::Cycles_480,
+    }
+}

--- a/firmware/src/usb.rs
+++ b/firmware/src/usb.rs
@@ -1,44 +1,150 @@
-use crate::tablet::Report;
-use cortex_m::interrupt::free as disable_interrupts;
-use stm32f4xx_hal::otg_fs::{USB, UsbBus};
-use usb_device::{bus::UsbBusAllocator, prelude::*};
-use usbd_hid::{descriptor::generator_prelude::*, hid_class::HIDClass};
+use core::mem::MaybeUninit;
+
+use stm32f4xx_hal::otg_fs::{USB, UsbBus, UsbBusType};
+use usb_device::{
+    LangID,
+    bus::UsbBusAllocator,
+    device::{StringDescriptors, UsbDevice, UsbDeviceBuilder, UsbDeviceState, UsbVidPid},
+};
+use usbd_hid::hid_class::HIDClass;
+use usbd_serial::SerialPort;
 
 // todo: https://pid.codes
 const VENDOR_ID: u16 = /***/ 0x1209; // 4617
-const PRODUCT_ID: u16 = /**/ 0x02D7; // 727
+const PRODUCT_ID: u16 = /**/ 0x02D7; // 727 WYSFI
 
-static mut EP_MEMORY: [u32; 1024] = [0; 1024];
-static mut USB_ALLOCATOR: Option<UsbBusAllocator<UsbBus<USB>>> = None;
-static mut USB_HID: Option<HIDClass<UsbBus<USB>>> = None;
-static mut USB_BUS: Option<UsbDevice<UsbBus<USB>>> = None;
+pub const HID_REPORT_SIZE_BYTES: usize = 8;
 
-pub fn setup(usb: USB) {
-    let bus_allocator = unsafe {
-        USB_ALLOCATOR = Some(UsbBus::new(usb, &mut EP_MEMORY));
-        USB_ALLOCATOR.as_ref().unwrap()
-    };
-    unsafe {
-        USB_HID = Some(HIDClass::new(&bus_allocator, Report::desc(), 1));
-        USB_BUS = Some(
-            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(VENDOR_ID, PRODUCT_ID))
-                .strings(&[StringDescriptors::new(LangID::EN)
-                    .manufacturer("Wonkle")
-                    .product("Wonkleboard mk.1 Pro")])
-                .unwrap()
-                .build(),
-        );
-    };
+/// Endpoint memory size for the OTG-FS peripheral in 32-bit words.
+/// Generous for HID + CDC.
+const EP_MEMORY_WORDS: usize = 1024;
+
+// Endpoint memory
+static mut EP_MEMORY: [u32; EP_MEMORY_WORDS] = [0; EP_MEMORY_WORDS];
+
+static mut USB_BUS: MaybeUninit<UsbBusAllocator<UsbBusType>> = MaybeUninit::uninit();
+
+/// HID report descriptor
+/// - a digitizer (Stylus)
+/// - 3 buttons
+/// - 16-bit X/Y in 0..=10000
+/// - 16-bit tip-pressure in 0..=2047
+pub const HID_DESCRIPTOR: [u8; 76] = [
+    0x05, 0x0D, //       Usage Page (Digitizer)
+    0x09, 0x01, //       Usage (Digitizer)
+    0xA1, 0x01, //       Collection (Application)
+    0x09, 0x20, //         Usage (Stylus)
+    0xA1, 0x00, //         Collection (Physical)
+    0x75, 0x08, //           Report Size (8)
+    0x95, 0x01, //           Report Count (1)
+    0x81, 0x03, //           Input (Cnst,Var,Abs) ; byte 0 unused
+    0x05, 0x09, //           Usage Page (Button)
+    0x19, 0x01, //           Usage Minimum (1)
+    0x29, 0x03, //           Usage Maximum (3)
+    0x15, 0x00, //           Logical Minimum (0)
+    0x25, 0x01, //           Logical Maximum (1)
+    0x75, 0x01, //           Report Size (1)
+    0x95, 0x03, //           Report Count (3)
+    0x81, 0x02, //           Input (Data,Var,Abs) ; buttons
+    0x75, 0x05, //           Report Size (5)
+    0x95, 0x01, //           Report Count (1)
+    0x81, 0x03, //           Input (Cnst,Var,Abs) ; padding
+    0x05, 0x01, //           Usage Page (Generic Desktop)
+    0x09, 0x30, //           Usage (X)
+    0x16, 0x00, 0x00, // Logical Minimum (0)
+    0x26, 0x10, 0x27, // Logical Maximum (10000)
+    0x75, 0x10, //           Report Size (16)
+    0x95, 0x01, //           Report Count (1)
+    0x81, 0x02, //           Input (Data,Var,Abs) ; X
+    0x09, 0x31, //           Usage (Y)
+    0x81, 0x02, //           Input (Data,Var,Abs) ; Y
+    0x05, 0x0D, //           Usage Page (Digitizer)
+    0x09, 0x30, //           Usage (Tip Pressure)
+    0x16, 0x00, 0x00, // Logical Minimum (0)
+    0x26, 0xFF, 0x07, // Logical Maximum (2047)
+    0x75, 0x10, //           Report Size (16)
+    0x95, 0x01, //           Report Count (1)
+    0x81, 0x02, //           Input (Data,Var,Abs) ; pressure
+    0xC0, //               End Collection
+    0xC0, //             End Collection
+];
+
+pub struct Usb {
+    device: UsbDevice<'static, UsbBusType>,
+    serial_port: SerialPort<'static, UsbBusType>,
+    hid: HIDClass<'static, UsbBusType>,
 }
 
-pub fn push(report: Report) -> Result<usize, usb_device::UsbError> {
-    disable_interrupts(|_| unsafe { USB_HID.as_mut().map(|hid| hid.push_input(&report)) }).unwrap()
+pub fn build(usb_peripheral: USB) -> Usb {
+    let ep_mem: &'static mut [u32; EP_MEMORY_WORDS] = unsafe { &mut EP_MEMORY };
+    let bus_allocator: &'static mut usb_device::bus::UsbBusAllocator<UsbBusType> =
+        unsafe { USB_BUS.write(UsbBus::new(usb_peripheral, ep_mem)) };
+
+    let serial_port = SerialPort::new(bus_allocator);
+    let hid = HIDClass::new_ep_in(bus_allocator, &HID_DESCRIPTOR[..], 1);
+    let device = UsbDeviceBuilder::new(bus_allocator, UsbVidPid(VENDOR_ID, PRODUCT_ID))
+        .strings(&[StringDescriptors::new(LangID::EN)
+            .manufacturer("Wonkle")
+            .product("Wonkleboard mk.1 Pro")])
+        .unwrap()
+        .composite_with_iads()
+        .max_power(500) // mA
+        .unwrap()
+        .build();
+
+    Usb {
+        device,
+        serial_port,
+        hid,
+    }
 }
 
-pub fn poll() {
-    unsafe {
-        if let (Some(usb_dev), Some(hid)) = (USB_BUS.as_mut(), USB_HID.as_mut()) {
-            usb_dev.poll(&mut [hid]);
+impl Usb {
+    pub fn poll(&mut self) -> bool {
+        self.device
+            .poll(&mut [&mut self.serial_port, &mut self.hid])
+    }
+
+    pub fn configured(&self) -> bool {
+        matches!(self.device.state(), UsbDeviceState::Configured)
+    }
+
+    pub fn send_hid_report(&self, data: &[u8]) -> bool {
+        if !self.configured() {
+            return false;
         }
-    };
+        self.hid.push_raw_input(data).is_ok()
+    }
+
+    pub fn cdc_send_frame(&mut self, data: &[u8]) -> bool {
+        if !self.configured() {
+            return false;
+        }
+
+        let mut offset = 0;
+        let mut idle = 0;
+
+        while offset < data.len() {
+            match self.serial_port.write(&data[offset..]) {
+                Ok(n) if n > 0 => {
+                    offset += n;
+                    idle = 0;
+                }
+                Ok(_) => idle += 1,
+                Err(usb_device::UsbError::WouldBlock) => idle += 1,
+                Err(_) => return false,
+            }
+            if idle >= 200 {
+                return false;
+            }
+            self.device
+                .poll(&mut [&mut self.serial_port, &mut self.hid]);
+        }
+
+        true
+    }
+
+    pub fn cdc_rx_pop(&mut self, buf: &mut [u8]) -> usize {
+        self.serial_port.read(buf).unwrap_or_default()
+    }
 }


### PR DESCRIPTION
### What's new:
- `CDC telemetry` - binary protocol over USB serial for debug/analysis: grid streaming, performance statistics, runtime sensor parameter tuning - it allows to build web configurator
- `Profiler` - per-iteration cycle measurements with periodic Hz/µs reports
- `Direct register ADC` - bypass HAL for speed, oversampling, re-reads, configurable mux settling
- `Centroid + EMA` - weighted centroid with neighbor clustering, cursor smoothing _(optional)_, 8-byte packed HID report
    - *Neighbor clustering to w/a noise spikes observed with current hardware
- `Composite USB` - HID digitizer + CDC serial on one device.

### Explicit decisions:
- System clock capped at 84MHz due to hard faults with higher rates, goal is 168MHz minimum
- `USB_ENUMERATION_DELAY_MS` - added in case of invalid system clock setting so there's window to reflash wrong firmware before it hard faults and gets stuck in a reboot loop
- Without micro-optimizations yet


Ported to rust from [cpp version](https://github.com/mieshki/wonkle) 